### PR TITLE
add initial benchmarks

### DIFF
--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,5 +1,37 @@
+{-# LANGUAGE BangPatterns #-}
+
+{-# OPTIONS_GHC -O2 #-}
+
+import CoercibleUtils
+import Data.Monoid (Sum(..))
 import Gauge.Main
+import Prelude hiding (sum)
+import qualified Data.Foldable as Foldable
 
 main :: IO ()
-main = defaultMain [bench "const" (whnf const ())]
+main = do
+  let nums10     = [1..10]
+      nums100    = [1..100]
+      nums1000   = [1..1000]
+      nums10000  = [1..10000]
+      nums100000 = [1..100000] 
+  defaultMain
+    [ bgroup "coercible-utils"
+      [ bench "CoercibleUtils.sum: 10"      $ whnf          sum nums10
+      , bench "Data.Foldable.sum:  10"      $ whnf Foldable.sum nums10
+      , bench "CoercibleUtils.sum: 100"     $ whnf          sum nums100
+      , bench "Data.Foldable.sum:  100"     $ whnf Foldable.sum nums100
+      , bench "CoercibleUtils.sum: 1000"    $ whnf          sum nums1000
+      , bench "Data.Foldable.sum:  1000"    $ whnf Foldable.sum nums1000
+      , bench "CoercibleUtils.sum: 10000"   $ whnf          sum nums10000
+      , bench "Data.Foldable.sum:  10000"   $ whnf Foldable.sum nums10000
+      , bench "CoercibleUtils.sum: 100000"  $ whnf          sum nums100000
+      , bench "Data.Foldable.sum:  100000"  $ whnf Foldable.sum nums100000
 
+      
+      ]
+    ]
+
+sum :: [Int] -> Int
+sum xs = ala Sum foldMap xs
+{-# INLINE sum #-}


### PR DESCRIPTION
```bash
benchmarked coercible-utils/CoercibleUtils.sum: 10
time                 34.44 ns   (32.94 ns .. 36.22 ns)
                     0.974 R²   (0.958 R² .. 0.989 R²)
mean                 37.09 ns   (35.99 ns .. 40.36 ns)
std dev              5.781 ns   (2.496 ns .. 10.93 ns)
variance introduced by outliers: 80% (severely inflated)

benchmarked coercible-utils/Data.Foldable.sum:  10
time                 66.80 ns   (61.23 ns .. 70.78 ns)
                     0.973 R²   (0.952 R² .. 0.991 R²)
mean                 71.33 ns   (69.68 ns .. 72.63 ns)
std dev              5.377 ns   (3.834 ns .. 7.405 ns)
variance introduced by outliers: 51% (severely inflated)

benchmarked coercible-utils/CoercibleUtils.sum: 100
time                 309.8 ns   (304.0 ns .. 317.2 ns)
                     0.998 R²   (0.996 R² .. 1.000 R²)
mean                 308.9 ns   (307.3 ns .. 310.5 ns)
std dev              5.713 ns   (3.830 ns .. 7.962 ns)

benchmarked coercible-utils/Data.Foldable.sum:  100
time                 746.9 ns   (713.4 ns .. 776.1 ns)
                     0.990 R²   (0.984 R² .. 0.994 R²)
mean                 709.1 ns   (686.8 ns .. 735.2 ns)
std dev              89.66 ns   (66.11 ns .. 121.9 ns)
variance introduced by outliers: 71% (severely inflated)

benchmarked coercible-utils/CoercibleUtils.sum: 1000
time                 2.982 μs   (2.948 μs .. 3.027 μs)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 2.985 μs   (2.971 μs .. 3.007 μs)
std dev              60.24 ns   (44.72 ns .. 86.23 ns)

benchmarked coercible-utils/Data.Foldable.sum:  1000
time                 7.491 μs   (7.324 μs .. 7.709 μs)
                     0.993 R²   (0.987 R² .. 0.996 R²)
mean                 6.859 μs   (6.604 μs .. 7.052 μs)
std dev              735.6 ns   (589.1 ns .. 860.8 ns)
variance introduced by outliers: 64% (severely inflated)

benchmarked coercible-utils/CoercibleUtils.sum: 10000
time                 115.1 μs   (110.7 μs .. 119.8 μs)
                     0.992 R²   (0.978 R² .. 0.999 R²)
mean                 115.9 μs   (113.5 μs .. 121.6 μs)
std dev              12.70 μs   (3.878 μs .. 27.69 μs)
variance introduced by outliers: 64% (severely inflated)

benchmarked coercible-utils/Data.Foldable.sum:  10000
time                 73.38 μs   (72.23 μs .. 74.14 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 73.93 μs   (73.53 μs .. 74.78 μs)
std dev              1.820 μs   (1.312 μs .. 2.399 μs)

benchmarked coercible-utils/CoercibleUtils.sum: 100000
time                 1.651 ms   (1.600 ms .. 1.701 ms)
                     0.995 R²   (0.990 R² .. 0.998 R²)
mean                 1.642 ms   (1.621 ms .. 1.723 ms)
std dev              111.4 μs   (49.73 μs .. 228.6 μs)
variance introduced by outliers: 42% (moderately inflated)

benchmarked coercible-utils/Data.Foldable.sum:  100000
time                 777.4 μs   (738.1 μs .. 800.6 μs)
                     0.988 R²   (0.970 R² .. 0.997 R²)
mean                 797.0 μs   (782.6 μs .. 819.0 μs)
std dev              53.23 μs   (32.48 μs .. 80.07 μs)
variance introduced by outliers: 40% (moderately inflated)
```

It looks like we do better for sufficiently small lists. Somewhere between the size of 10^3 and 10^4 we start losing out.