### PR TITLE
Improve inference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,6 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.4], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.0.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.10.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
 
 before_install:
   - HC=/opt/ghc/bin/${CC}

--- a/coercible-utils.cabal
+++ b/coercible-utils.cabal
@@ -13,10 +13,7 @@ category:            Control
 build-type:          Simple
 extra-doc-files:     CHANGELOG.md
 cabal-version:       1.24
-tested-with:         GHC == 7.10.3
-                   , GHC == 8.0.2
-                   , GHC == 8.2.2
-                   , GHC == 8.4.3
+tested-with:         GHC == 8.4.3
                    , GHC == 8.6.4
 
 library
@@ -25,7 +22,7 @@ library
                      , Control.Newtype.Generic
                        
   ghc-options:         -Wall
-  build-depends:       base >= 4.8 && < 4.13
+  build-depends:       base >= 4.11 && < 4.13
                      
   default-language:    Haskell2010
   

--- a/src/Control/Newtype/Generic.hs
+++ b/src/Control/Newtype/Generic.hs
@@ -35,14 +35,20 @@ this version has two parameters: one for the newtype and one for the
 underlying type. This generally makes 'Newtype' constraints more compact
 and easier to read.
 
-Unlike the versions in "CoercibleUtils", one of the "packers" must
-operate on only one newtype layer at a time; this improves inference at
-the expense of a little flexibility.
-
 Note: Each function in this module takes an argument representing a
 newtype constructor (or similar). This is used only for its type. To make that clear,
 the type of that argument is allowed to be extremely polymorphic: @o \`to\` n@
 rather than @o -> n@.
+
+General approach: When the type variables @n@ and @o@ appear, @n@ is /typically/
+expected to be a newtype wrapper around @o@. However, if the function takes a
+value of type @n \`to\` o@, then @n@ can be any @Generic@ newtype and @o@ can be
+any type coercible with it. It's not clear whether this extra generality over
+the @newtype@ package is useful or not, but it shouldn't harm inference
+significantly. When the type variables @n'@ and @o'@ appear as well, @n'@ is
+/required/ to be a newtype wrapper around @o'@, and, furthermore, @n@ and
+@n'@ are required to be the /same newtype/, with possibly different type
+arguments. See 'Similar' for detailed documentation.
 
 @since TODO
 -}


### PR DESCRIPTION
The original concept of this API is to work "over", "under", or
"a la" a *single* newtype, potentially changing its type arguments
but not changing it wholesale. Back in the day, Haskell couldn't
express that idea, but now it can (for the most part). We can take
advantage of that to improve inference and typed hole error messages.

Fixes #15

Additionally, remove support for GHC versions before 8.4. These have pretty horribly brittle support for `Coercible` (7.10 being especially different and 8.2 being especially flaky), so supporting them is a bit nightmarish.