### PR TITLE
Refactor the module structure

### DIFF
--- a/coercible-utils.cabal
+++ b/coercible-utils.cabal
@@ -19,7 +19,8 @@ tested-with:         GHC == 8.4.3
 library
   hs-source-dirs:      src
   exposed-modules:     CoercibleUtils
-                     , Control.Newtype.Generic
+                     , CoercibleUtils.Compose
+                     , CoercibleUtils.Newtype
                        
   ghc-options:         -Wall
   build-depends:       base >= 4.11 && < 4.13

--- a/src/CoercibleUtils.hs
+++ b/src/CoercibleUtils.hs
@@ -1,24 +1,11 @@
 {-# language TypeOperators #-}
 
 {- |
-Primarily pulled from the
-package @[newtype-generics](http://hackage.haskell.org/package/newtype-generics)@,
-and based on Conor McBride's Epigram work, but
-generalised to work over anything `Coercible`.
+This module reexports the entire content of the `coercible-utils` package.
 
->>> ala Sum foldMap [1,2,3,4 :: Int] :: Int
-10
+See the 'CoercibleUtils.Newtype' module for the newtype combinators.
 
->>> ala Endo foldMap [(+1), (+2), (subtract 1), (*2) :: Int -> Int] (3 :: Int) :: Int
-8
-
->>> under2 Min (<>) 2 (1 :: Int) :: Int
-1
-
->>> over All not (All False) :: All
-All {getAll = True}
-
-__Note__: All of the functions in this module take an argument that solely
+__Note__: Most functions in this package take an argument that solely
 directs the /type/ of the coercion. The value of this argument is /ignored/.
 In each case, this argument has a type that looks like @a \`to\` b@. As the name
 of the @to@ type variable suggests, this will typically be a function from
@@ -27,175 +14,9 @@ unconstrained lets the type signature communicate the fact that the argument
 is not used.
 -}
 module CoercibleUtils
-  ( -- * Coercive composition
-    (#.), (.#)
-
-    -- * The classic "newtype" combinators
-  , op
-  , ala, ala'
-  , under, over
-  , under2, over2
-  , underF, overF
+  ( module CoercibleUtils.Newtype
+  , (#.), (.#)
   ) where
 
-import Data.Coerce (Coercible, coerce)
-
--- | Coercive left-composition.
---
--- >>> (All #. not) True
--- All {getAll = False}
---
--- The semantics with respect to bottoms are:
---
--- @
--- p '#.' ⊥ ≡ ⊥
--- p '#.' f ≡ p '.' f
--- @
-infixr 9 #.
-(#.) :: Coercible b c => (b `to` c) -> (a -> b) -> a -> c
-(#.) _ = coerce
-{-# INLINE (#.) #-}
-
--- | Coercive right-composition.
---
--- >>> (stimes 2 .# Product) 3
--- Product {getProduct = 9}
---
--- The semantics with respect to bottoms are:
---
--- @
--- ⊥ '.#' p ≡ ⊥
--- f '.#' p ≡ p '.' f
--- @
-infixr 9 .#
-(.#) :: Coercible a b => (b -> c) -> (a `to` b) -> a -> c
-(.#) f _ = coerce f
-{-# INLINE (.#) #-}
-
--- | Reverse the type of a "packer".
---
--- >>> op All (All True)
--- True
--- >>> op (Identity . Sum) (Identity (Sum 3))
--- 3
-op :: Coercible a b
-   => (a `to` b)
-   -> b
-   -> a
-op _ = coerce
-{-# INLINE op #-}
-
--- | The workhorse of the package. Given a "packer" and a \"higher order function\" (/hof/),
--- it handles the packing and unpacking, and just sends you back a regular old
--- function, with the type varying based on the /hof/ you passed.
---
--- The reason for the signature of the /hof/ is due to 'ala' not caring about structure.
--- To illustrate why this is important, consider this alternative implementation of 'under2':
---
--- @
--- under2' :: (Coercible a b, Coercible a' b')
---         => (a -> b) -> (b -> b -> b') -> (a -> a -> a')
--- under2' pa f o1 o2 = 'ala' pa (\\p -> uncurry f . bimap p p) (o1, o2)
--- @
---
--- Being handed the "packer", the /hof/ may apply it in any structure of its choosing –
--- in this case a tuple.
---
--- >>> ala Sum foldMap [1,2,3,4 :: Int] :: Int
--- 10
-ala :: (Coercible a b, Coercible a' b')
-    => (a `to` b)
-    -> ((a -> b) -> c -> b')
-    -> c
-    -> a'
-ala pa hof = ala' pa hof id
-{-# INLINE ala #-}
-
--- | The way it differs from the 'ala' function in this package,
---   is that it provides an extra hook into the \"packer\" passed to the hof.
--- 
---   However, this normally ends up being 'id', so 'ala' wraps this function and
---   passes 'id' as the final parameter by default.
---   If you want the convenience of being able to hook right into the /hof/,
---   you may use this function.
---
--- >>> ala' Sum foldMap length ["hello", "world"] :: Int
--- 10
---
--- >>> ala' First foldMap (readMaybe @Int) ["x", "42", "1"] :: Maybe Int
--- Just 42
-ala' :: (Coercible a b, Coercible a' b')
-     => (a `to` b)
-     -> ((d -> b) -> c -> b')
-     -> (d -> a)
-     -> c
-     -> a'
-ala' _ hof f = coerce #. hof (coerce f)
-{-# INLINE ala' #-}
-
--- | A very simple operation involving running the function /under/ the "packer".
---
--- >>> under Product (stimes 3) (3 :: Int) :: Int
--- 27
-under :: (Coercible a b, Coercible a' b')
-      => (a `to` b)
-      -> (b -> b')
-      -> a
-      -> a'
-under _ f = coerce f
-{-# INLINE under #-}
-
--- | The opposite of 'under'. I.e., take a function which works on the
---   underlying "unpacked" types, and switch it to a function that works
---   on the "packer".
---
--- >>> over All not (All False) :: All
--- All {getAll = True}
-over :: (Coercible a b, Coercible a' b')
-     => (a `to` b)
-     -> (a -> a')
-     -> b
-     -> b'
-over _ f = coerce f
-{-# INLINE over #-}
-
--- | Lower a binary function to operate on the underlying values.
---
--- >>> under2 Any (<>) True False :: Bool
--- True
-under2 :: (Coercible a b, Coercible a' b')
-       => (a `to` b)
-       -> (b -> b -> b')
-       -> a
-       -> a
-       -> a'
-under2 _ f = coerce f
-{-# INLINE under2 #-}
-
--- | The opposite of 'under2'.
-over2 :: (Coercible a b, Coercible a' b')
-      => (a `to` b)
-      -> (a -> a -> a')
-      -> b
-      -> b
-      -> b'
-over2 _ f = coerce f
-{-# INLINE over2 #-}
-
--- | 'under' lifted into a 'Functor'.
-underF :: (Coercible a b, Coercible a' b', Functor f, Functor g)
-       => (a `to` b)
-       -> (f b -> g b')
-       -> f a
-       -> g a'
-underF _ f = fmap coerce . f . fmap coerce
-{-# INLINE underF #-}
-
--- | 'over' lifted into a 'Functor'.
-overF :: (Coercible a b, Coercible a' b', Functor f, Functor g)
-      => (a `to` b)
-      -> (f a -> g a')
-      -> f b
-      -> g b'
-overF _ f = fmap coerce . f . fmap coerce
-{-# INLINE overF #-}
+import CoercibleUtils.Compose ((#.), (.#))
+import CoercibleUtils.Newtype

--- a/src/CoercibleUtils/Compose.hs
+++ b/src/CoercibleUtils/Compose.hs
@@ -1,0 +1,51 @@
+{-# language TypeOperators #-}
+
+{-|
+Coercive function composition.
+
+__Note__: The functions in this module take an argument that solely
+directs the /type/ of the coercion. The value of this argument is /ignored/.
+In each case, this argument has a type that looks like @a \`to\` b@. As the name
+of the @to@ type variable suggests, this will typically be a function from
+@a@ to @b@. But leaving the type variable completely polymorphic and
+unconstrained lets the type signature communicate the fact that the argument
+is not used.
+-}
+module CoercibleUtils.Compose
+  ( (#.)
+  , (.#)
+  ) where
+
+import Data.Coerce (Coercible, coerce)
+
+-- | Coercive left-composition.
+--
+-- >>> (All #. not) True
+-- All {getAll = False}
+--
+-- The semantics with respect to bottoms are:
+--
+-- @
+-- p '#.' ⊥ ≡ ⊥
+-- p '#.' f ≡ p '.' f
+-- @
+infixr 9 #.
+(#.) :: Coercible b c => (b `to` c) -> (a -> b) -> a -> c
+(#.) _ = coerce
+{-# INLINE (#.) #-}
+
+-- | Coercive right-composition.
+--
+-- >>> (stimes 2 .# Product) 3
+-- Product {getProduct = 9}
+--
+-- The semantics with respect to bottoms are:
+--
+-- @
+-- ⊥ '.#' p ≡ ⊥
+-- f '.#' p ≡ p '.' f
+-- @
+infixr 9 .#
+(.#) :: Coercible a b => (b -> c) -> (a `to` b) -> a -> c
+(.#) f _ = coerce f
+{-# INLINE (.#) #-}

--- a/src/CoercibleUtils/Newtype.hs
+++ b/src/CoercibleUtils/Newtype.hs
@@ -36,7 +36,7 @@ Like McBride's version, and unlike the one in @newtype-generics@, this version
 has two parameters: one for the newtype and one for the underlying type. This
 is mostly a matter of taste.
 
-Note: Each function in this module takes an argument representing a newtype
+__Note__: Most functions in this module take an argument representing a newtype
 constructor. This is used only for its type. To make that clear, the type of
 that argument is allowed to be extremely polymorphic: @o \`to\` n@ rather than
 @o -> n@. Unfortunately, GHCi displays this as @to o n@, which is ugly but
@@ -51,7 +51,7 @@ documentation.
 
 @since TODO
 -}
-module Control.Newtype.Generic
+module CoercibleUtils.Newtype
   ( Newtype
   , IsNewtype
   , HasUnderlying
@@ -73,7 +73,7 @@ module Control.Newtype.Generic
 import GHC.Generics
 import Data.Coerce
 import GHC.TypeLits (TypeError, ErrorMessage (..))
-import CoercibleUtils (op, (#.), (.#))
+import CoercibleUtils.Compose ((#.), (.#))
 import Data.Kind (Constraint)
 
 -- | Get the underlying type of a newtype.
@@ -232,6 +232,18 @@ pack = coerce
 unpack :: Newtype n o => n -> o
 unpack = coerce
 
+-- | Reverse the type of a "packer".
+--
+-- >>> op All (All True)
+-- True
+-- >>> op (Identity . Sum) (Identity (Sum 3))
+-- 3
+op :: Coercible a b
+   => (a `to` b)
+   -> b
+   -> a
+op _ = coerce
+{-# INLINE op #-}
 
 -- | The workhorse of the package. Given a "packer" and a \"higher order function\" (/hof/),
 -- it handles the packing and unpacking, and just sends you back a regular old


### PR DESCRIPTION
* Rename Control.Newtype.Generic to CoercibleUtils.Newtype
* Move (#.) and (.#) to CoercibleUtils.Compose
* Reexport both modules from CoercibleUtils

This removes the old newtype combinators.